### PR TITLE
fixing everything forr TDD eval

### DIFF
--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -30,22 +30,49 @@ class EnigmaTest < Minitest::Test
   def test_that_it_can_convert_dates_if_need_be
     enigma = Enigma.new
     date = Time.new
+    expected = date.strftime("%d%m%y")
 
-    assert_equal "051118", enigma.date_converter(date)
+    assert_equal expected, enigma.date_converter(date)
   end
 
-  def test_that_it_can_encrypt_a_message_with_a_key_and_NOT_a_date
+  def test_that_it_can_encrypt_a_message_with_a_key_and_no_date
     enigma = Enigma.new
     key = "02715"
-    date = Time.new
     message_1 = "hello world"
-    expected = {
-         encryption: "snddziogbuw",
-         key: "02715",
-         date: "051118"
-       }
+    actual = enigma.encrypt(message_1, key)
+    date = Time.now.strftime("%d%m%y")
 
-    assert_equal expected, enigma.encrypt(message_1, key, date)
+    assert_equal 3, actual.keys.length
+    assert_equal 3, actual.values.length
+    assert_equal :encryption, actual.keys[0]
+    assert_equal Symbol, actual.keys[1].class
+    assert_equal String, actual.values[2].class
+    assert_equal date, actual[:date]
+  end
+
+  def test_that_it_can_encrypt_a_message_with_a_date_and_no_key
+    enigma = Enigma.new
+    date = "300484"
+    message_1 = "hello world"
+    actual = enigma.encrypt(message_1, date)
+
+    assert_equal 3, actual.keys.length
+    assert_equal 3, actual.values.length
+    assert_equal :encryption, actual.keys[0]
+    assert_equal Symbol, actual.keys[1].class
+    assert_equal String, actual.values[2].class
+  end
+
+  def test_that_it_can_encrypt_a_message_with_no_key_or_date
+    enigma = Enigma.new
+    message_1 = "hello world"
+    actual = enigma.encrypt(message_1)
+
+    assert_equal 3, actual.keys.length
+    assert_equal 3, actual.values.length
+    assert_equal :encryption, actual.keys[0]
+    assert_equal Symbol, actual.keys[1].class
+    assert_equal String, actual.values[2].class
   end
 
   def test_that_it_can_decrypt_a_message_with_a_key_and_date
@@ -65,35 +92,51 @@ class EnigmaTest < Minitest::Test
   def test_that_it_can_decrypt_a_message_with_a_key_and_a_date_of_now
     enigma = Enigma.new
     key = "02715"
+    date = Time.now.strftime("%d%m%y")
     encrypted = {
          encryption: "snddziogbuw",
          key: "02715",
-         date: "051118"
+         date: date
        }
     expected = {
          decryption: "hello world",
          key: "02715",
-         date: "051118"
+         date: date
        }
-       
+
+    assert_equal expected, enigma.decrypt(encrypted[:encryption], key, date)
+  end
+
+  def test_that_it_can_decrypt_a_message_with_a_key_and_no_date
+    enigma = Enigma.new
+    key = "02715"
+    date = Time.now.strftime("%d%m%y")
+    encrypted = {
+         encryption: "snddziogbuw",
+         key: "02715",
+         date: date
+       }
+    expected = {
+         decryption: "hello world",
+         key: "02715",
+         date: date
+       }
+
     assert_equal expected, enigma.decrypt(encrypted[:encryption], key)
   end
 
   def test_that_it_can_encrypt_a_message_with_randomly_generated_number_and_todays_date
     enigma = Enigma.new
-    message_1 = "hello world"
+    date = Time.now.strftime("%d%m%y")
     encrypted = {
          encryption: "hpuzokebrwm",
          key: "45610",
-         date: "051118"
+         date: date
        }
-       #how do you test for a day that always changes
-    # assert_equal encrypted, enigma.encrypt(message_1)
-
     expected_decryption = {
          decryption: "hello world",
          key: "45610",
-         date: "051118"
+         date: date
        }
 
     assert_equal expected_decryption, enigma.decrypt(encrypted[:encryption], "45610")

--- a/test/rotator_test.rb
+++ b/test/rotator_test.rb
@@ -19,60 +19,64 @@ class RotatorTest < Minitest::Test
 
   def test_that_it_can_rotate_a_letter_upcase_or_down_results_in_downcase
     rotator = Rotator.new
-    shift_1 = Shift.new("05412")
-    shift_amounts_1 = shift_1.shift_values
+    shift_amounts_1 = [14, 63, 43, 16]
 
     assert_equal "o", rotator.rotate_forwards("a", shift_amounts_1)
     assert_equal "o", rotator.rotate_forwards("A", shift_amounts_1)
 
-    shift_2 = Shift.new("78234")
-    shift_amounts_2 = shift_2.shift_values
-    # figure this out by hand
+    shift_amounts_2 = [87, 91, 25, 38]
+
     assert_equal "g", rotator.rotate_forwards("a", shift_amounts_2)
   end
 
   def test_that_it_can_rotate_and_produce_an_encoded_word
     rotator = Rotator.new
-    shift_1 = Shift.new("05412")
-    shift_amounts_1 = shift_1.shift_values
+    shift_amounts_1 = [14, 63, 43, 16]
 
     assert_equal "vnaab", rotator.rotate_forwards("hello", shift_amounts_1)
 
-    shift_2 = Shift.new("78234")
-    shift_amounts_2 = shift_2.shift_values
-    # figure this out by hand
+    shift_amounts_2 = [87, 91, 25, 38]
+
     assert_equal "nojwu", rotator.rotate_forwards("hello", shift_amounts_2)
   end
 
   def test_that_it_returns_unknown_characters_as_themselves
     rotator = Rotator.new
-    shift = Shift.new("05412")
-    shift_amounts = shift.shift_values
+    shift_amounts = [14, 63, 43, 16]
 
     assert_equal "o!", rotator.rotate_forwards("a!", shift_amounts)
   end
 
   def test_that_it_can_take_a_Shift_value_and_use_it
     rotator = Rotator.new
-    shift = Shift.new("05412", "040895")
-    shift_amounts = shift.shift_values
+    shift_amounts = [03, 27, 73, 20]
     actual_1 = rotator.rotate_forwards("a", shift_amounts)
 
-    assert_equal "g", actual_1
+    assert_equal "d", actual_1
 
     actual_2 = rotator.rotate_forwards("hello world", shift_amounts)
 
-    assert_equal "neabu lexlt", actual_2
+    assert_equal "keder ohulw", actual_2
   end
 
   def test_that_it_can_decrypt_with_shift_value_also
     rotator = Rotator.new
-    shift = Shift.new("05412")
-    shift_amounts = shift.shift_values
+    shift_amounts = [14, 63, 43, 16]
     encoded_message = rotator.rotate_forwards("hello world", shift_amounts)
     actual = "hello world"
 
     assert_equal actual, rotator.rotate_backwards(encoded_message, shift_amounts)
+  end
+
+  def test_that_it_can_convert_letters
+    rotator = Rotator.new
+    character = "m"
+    index = 0
+    shift_amounts = [14, 63, 43, 16]
+    direction = -1
+    actual = rotator.letter_conversion(character, index, shift_amounts, direction)
+
+    assert_equal "z", actual
   end
 
 end

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -29,7 +29,7 @@ class ShiftTest < Minitest::Test
   def test_that_it_can_mmddyy_a_date_object_or_to_i_a_date_string
     shift = Shift.new("02715")
 
-    assert_equal 51118, shift.date_format
+    assert_equal Integer, shift.date_format.class
 
     shift = Shift.new("02715", "040895")
 


### PR DESCRIPTION
Tests fail because dates were hardcoded for yesterday.
* changed dates from being hard coded

Enigma test does not test that your can call encrypt without out a date and/or key. Also does not test you can call decrypt without a date
*added tests for  encrypt without out a date and/or key
* added test for decrypt without a date

When the optional arguments are used, you aren't going to be able to assert EXACTLy what the output is, because there is an element of randomness. Instead, you should assert what you DO know about the output.
*I changed these to asserting things I knew about the output, not the precise output
*I still feel slightly concerned that this isn't enough, but maybe because testing random outputs can't be precise

In your Rotator Tests, instead of using the Shift class to get the shifts, just manually create an array with the shifts to remove dependency on other class and make your tests more clear. This would communicate that the rotate forwards method should receive an array of numbers.
* manually created arrays for the test

letter_conversion method not tested
*made test for letter conversion method